### PR TITLE
fix(driver): update device mount path to accommodate the new version …

### DIFF
--- a/pkg/controller/csi/driver.go
+++ b/pkg/controller/csi/driver.go
@@ -46,7 +46,7 @@ const (
 	podMountDirVolumeName    = "pod-mount"
 	deviceMountDirVolumeName = "device-mount"
 
-	deviceMountRelPath = "plugins/kubernetes.io/csi/volumeDevices"
+	deviceMountRelPath = "plugins/kubernetes.io/csi"
 
 	endpointENVName         = "CSI_ENDPOINT"
 	endpointInsideContainer = "/csi/csi.sock"


### PR DESCRIPTION
Pod needs to be restarted when PVC is expanded due to the change of device mount path